### PR TITLE
feat: record SWR data with useDebugValue

### DIFF
--- a/packages/swr-devtools/src/SWRDevTools.tsx
+++ b/packages/swr-devtools/src/SWRDevTools.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from "react";
+import React, { useDebugValue, useLayoutEffect } from "react";
 import { useSWRConfig, SWRConfig, Middleware, Cache } from "swr";
 
 import { injectSWRCache, isMetaCache } from "./swr-cache";
@@ -45,7 +45,14 @@ const swrdevtools: Middleware = (useSWRNext) => (key, fn, config) => {
     inject(cache);
     injected.add(cache);
   }
-  return useSWRNext(key, fn, config);
+  const result = useSWRNext(key, fn, config);
+
+  // Record SWR data in the Component panel of React Developer Tools
+  const { mutate, ...rest } = result;
+  const debugValue = { key, config, ...rest };
+  useDebugValue(debugValue);
+
+  return result;
 };
 
 export const SWRDevTools = ({ children }: { children: React.ReactNode }) => {


### PR DESCRIPTION
[useDebugValue](https://reactjs.org/docs/hooks-reference.html#usedebugvalue) can be used to display values in React Developer Tools.
This PR is to add `useDebugValue` in SWR DevTools middleware to display SWR data.

<img width="334" alt="image" src="https://user-images.githubusercontent.com/250407/142016395-b88526f8-a6b4-489f-bb55-b5497fb4229b.png">
