### PR TITLE
feat: support manifest v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 dist/
+dist-v2/
 extension.zip
+extension-v2.zip
 *.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "release": "lerna publish --conventional-commits",
     "start:demo": "yarn workspace swr-devtools-demo dev",
     "start:dev": "yarn workspace swr-devtools start",
-    "start:extensions": "yarn workspace swr-devtools-extensions start",
     "start:panel": "yarn workspace swr-devtools-panel start",
     "start": "run-p -l start:*",
     "v1": "yarn workspace swr-v1-devtools-demo dev",

--- a/packages/swr-devtools-extensions/manifest-v2.json
+++ b/packages/swr-devtools-extensions/manifest-v2.json
@@ -1,0 +1,29 @@
+{
+  "name": "SWR DevTools",
+  "description": "A DevTool to inspect your SWR cache",
+  "version": "0.3.0",
+  "manifest_version": 2,
+  "icons": {
+    "16": "icons/swr-devtools-16.png",
+    "48": "icons/swr-devtools-48.png",
+    "64": "icons/swr-devtools-64.png",
+    "128": "icons/swr-devtools-128.png"
+  },
+  "devtools_page": "devtools.html",
+  "background": {
+    "scripts": [
+      "background.js"
+    ]
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_start"
+    }
+  ]
+}

--- a/packages/swr-devtools-extensions/manifest.json
+++ b/packages/swr-devtools-extensions/manifest.json
@@ -2,7 +2,7 @@
   "name": "SWR DevTools",
   "description": "A DevTool to inspect your SWR cache",
   "version": "0.3.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "icons": {
     "16": "icons/swr-devtools-16.png",
     "48": "icons/swr-devtools-48.png",
@@ -11,9 +11,7 @@
   },
   "devtools_page": "devtools.html",
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
   "content_scripts": [
     {

--- a/packages/swr-devtools-extensions/package.json
+++ b/packages/swr-devtools-extensions/package.json
@@ -6,13 +6,19 @@
   "license": "MIT",
   "scripts": {
     "prebuild": "yarn clean",
-    "build:zip": "cd dist && zip -r ../extension.zip * && cd ../",
-    "build:webpack": "webpack --mode production",
-    "build": "run-s build:webpack build:zip",
-    "clean": "rimraf dist/ extension.zip",
+    "build:zip:chrome": "cd dist && zip -r ../extension.zip * && cd ../",
+    "build:webpack:chrome": "webpack --mode production",
+    "build:chrome": "run-s build:webpack:chrome build:zip:chrome",
+    "build:zip:firefox": "cd dist-v2 && zip -r ../extension-v2.zip * && cd ../",
+    "build:webpack:firefox": "MANIFEST_VERSION=2 webpack --mode production",
+    "build:firefox": "run-s build:webpack:firefox build:zip:firefox",
+    "build": "run-p build:chrome build:firefox",
+    "clean": "rimraf dist/ dist-v2/ extension.zip",
     "lint": "tsc --noEmit",
-    "start": "webpack --mode development --watch",
-    "start:firefox": "web-ext run -s dist"
+    "start:chrome": "webpack --mode development --watch",
+    "start:firefox:build": "MANIFEST_VERSION=2 webpack --mode development --watch",
+    "start:firefox:webext": "web-ext run -s dist-v2",
+    "start:firefox": "run-p start:firefox:*"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.154",

--- a/packages/swr-devtools-extensions/webpack.config.js
+++ b/packages/swr-devtools-extensions/webpack.config.js
@@ -9,7 +9,10 @@ module.exports = {
     devtools: "./src/devtools.ts",
   },
   output: {
-    path: path.resolve(__dirname, "dist"),
+    path: path.resolve(
+      __dirname,
+      process.env.MANIFEST_VERSION === "2" ? "dist-v2" : "dist"
+    ),
     filename: "[name].js",
   },
   devtool: "inline-source-map",
@@ -26,7 +29,13 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         { from: "src/*.html", to: "[name].html" },
-        { from: "manifest.json" },
+        {
+          from:
+            process.env.MANIFEST_VERSION === "2"
+              ? "manifest-v2.json"
+              : "manifest.json",
+          to: "manifest.json",
+        },
         { from: "icons/*.png" },
       ],
     }),


### PR DESCRIPTION
fixes #7 

This updates the manifest version to v3.
It works on Chrome👍, but it doesn't work with `web-ext`😭.
`web-ext` seems not to support manifest v3 yet, so we might have to separate build settings for Firefox.
https://github.com/mozilla/web-ext/issues/2379
