### PR TITLE
fix: a hydration error in SSR apps

### DIFF
--- a/packages/swr-devtools-extensions/manifest-v2.json
+++ b/packages/swr-devtools-extensions/manifest-v2.json
@@ -15,6 +15,12 @@
       "background.js"
     ]
   },
+  "permissions": [
+    "scripting",
+    "tabs",
+    "http://*/",
+    "https://*/"
+  ],
   "content_scripts": [
     {
       "matches": [

--- a/packages/swr-devtools-extensions/manifest.json
+++ b/packages/swr-devtools-extensions/manifest.json
@@ -13,6 +13,14 @@
   "background": {
     "service_worker": "background.js"
   },
+  "permissions": [
+    "scripting",
+    "tabs"
+  ],
+  "host_permissions": [
+    "http://*/",
+    "https://*/"
+  ],
   "content_scripts": [
     {
       "matches": [
@@ -23,18 +31,6 @@
         "content.js"
       ],
       "run_at": "document_start"
-    }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "web-accessible.js"
-      ],
-      "matches": [
-        "https://*/*",
-        "http://*/*"
-
-      ]
     }
   ]
 }

--- a/packages/swr-devtools-extensions/src/content.ts
+++ b/packages/swr-devtools-extensions/src/content.ts
@@ -1,14 +1,6 @@
 import { DevToolsMessage } from "swr-devtools";
 import { Runtime, runtime } from "webextension-polyfill";
 
-const injectDevToolsHook = () => {
-  const script = document.createElement("script");
-  script.setAttribute("type", "text/javascript");
-  script.setAttribute("src", chrome.runtime.getURL("web-accessible.js"));
-  document.documentElement.appendChild(script);
-};
-injectDevToolsHook();
-
 export type ContentMessage =
   | {
       type: "load";

--- a/packages/swr-devtools-extensions/src/devtools.ts
+++ b/packages/swr-devtools-extensions/src/devtools.ts
@@ -1,5 +1,16 @@
-import { devtools } from "webextension-polyfill";
+import { devtools, scripting } from "webextension-polyfill";
 
 devtools.panels.create("SWR", "", "panel.html").then(() => {
   console.log("The DevTools panel has been created");
 });
+
+scripting
+  .executeScript({
+    target: {
+      tabId: devtools.inspectedWindow.tabId,
+      allFrames: true,
+    },
+    files: ["web-accessible.js"],
+  })
+  .then((r) => console.log("executeScript has been success", r))
+  .catch((e) => console.log("executeScript has been failed", e));


### PR DESCRIPTION
Currently, SWRDevTools causes a hydration error with SSR apps because it inserts a script element in the application.
This PR has changed the way to inspect SWRDevTools middleware in to the application. I've used `scripting.executeScript` instead of adding a script element.

In order to use the API, I've added some permissions.

Before 
<img width="946" alt="Screen Shot 2022-07-12 at 23 54 32" src="https://user-images.githubusercontent.com/250407/178522051-27a02adc-8630-45b0-a186-422165f980ff.png">

After
<img width="947" alt="Screen Shot 2022-07-12 at 23 53 01" src="https://user-images.githubusercontent.com/250407/178522078-99b83c0b-a860-40e5-bed7-35043ab52204.png">

