### PR TITLE
fix: remove the inserted script after loading

### DIFF
--- a/packages/swr-devtools-extensions/src/content.ts
+++ b/packages/swr-devtools-extensions/src/content.ts
@@ -6,6 +6,7 @@ const injectDevToolsHook = () => {
   script.setAttribute("type", "text/javascript");
   script.setAttribute("src", chrome.runtime.getURL("web-accessible.js"));
   document.documentElement.appendChild(script);
+  script.parentNode?.removeChild(script);
 };
 injectDevToolsHook();
 


### PR DESCRIPTION
This is alternative of #76. This avoids hydration errors by removing inserted script after loading. We only want to defined `window.__SWR_DEVTOOLS_USE__`, so we can remove it after loading.