### PR TITLE
pref: run client scripts only when opening the DevTools Panel

### DIFF
--- a/packages/swr-devtools-extensions/src/app.tsx
+++ b/packages/swr-devtools-extensions/src/app.tsx
@@ -33,13 +33,7 @@ const port = runtime.connect({
 const root = createRoot(rootEl);
 const render = (el: ReactElement) => root.render(el);
 
-/*
-port.onDisconnect.addListener(() => {
-  cache.clear();
-  mounted = false;
-  render(<SWRDevToolPanel cache={null} events={null} />);
-});
-*/
+render(<SWRDevToolPanel cache={null} events={null} key="swr-not-found" />);
 
 let mounted = false;
 port.onMessage.addListener(

--- a/packages/swr-devtools-extensions/src/background.ts
+++ b/packages/swr-devtools-extensions/src/background.ts
@@ -4,9 +4,6 @@ import type { ContentMessage } from "./content";
 const contentPortMap = new Map();
 const panelPortMap = new Map();
 
-// queued messages until a panel is connected
-const queuedContentMessages: any[] = [];
-
 let showPanel = false;
 
 runtime.onConnect.addListener((port: Runtime.Port) => {
@@ -17,13 +14,6 @@ runtime.onConnect.addListener((port: Runtime.Port) => {
   if (port.name === "content") {
     contentPortMap.set(tabId, port);
     if (panelPortMap.has(tabId)) {
-      // notify that a panel is connected
-      /*
-      port.postMessage({
-        type: "displayed_panel",
-      });
-      */
-
       port.postMessage({
         type: showPanel ? "show_panel" : "hide_panel",
       });
@@ -39,8 +29,6 @@ runtime.onConnect.addListener((port: Runtime.Port) => {
           ...message,
           tabId,
         };
-
-        const panelPort = panelPortMap.get(tabId);
         /*
         console.log("sent message from content to panel", data, {
           sender,
@@ -49,31 +37,14 @@ runtime.onConnect.addListener((port: Runtime.Port) => {
           panelPort,
         });
         */
-        if (panelPort) {
-          panelPort.postMessage(data);
-        } else {
-          // not ready for sending messages
-          queuedContentMessages.push(data);
-        }
+
+        const panelPort = panelPortMap.get(tabId);
+        panelPort?.postMessage(data);
       }
     );
     // A port between the SWR panel in devtools
   } else if (port.name.startsWith("panel")) {
     panelPortMap.set(tabId, port);
-    // console.log("panelport", { tabId, panelPortMap, contentPortMap });
-    // if (contentPort) {
-    // notify that a panel is connected
-    /*
-      contentPort.postMessage({
-        type: "displayed_panel",
-      });
-      */
-    // }
-    // flush queued messages
-    if (queuedContentMessages.length > 0) {
-      queuedContentMessages.forEach((m) => port?.postMessage(m));
-      queuedContentMessages.length = 0;
-    }
     port.onDisconnect.addListener(() => {
       console.log("disconnected panel port => ", tabId);
       panelPortMap.delete(tabId);

--- a/packages/swr-devtools-extensions/src/background.ts
+++ b/packages/swr-devtools-extensions/src/background.ts
@@ -4,7 +4,7 @@ import type { ContentMessage } from "./content";
 const contentPortMap = new Map();
 const panelPortMap = new Map();
 
-let showPanel = false;
+let panelIsOpen = false;
 
 runtime.onConnect.addListener((port: Runtime.Port) => {
   const tabId = port.sender?.tab?.id || +port.name.replace("panel:", "");
@@ -15,7 +15,7 @@ runtime.onConnect.addListener((port: Runtime.Port) => {
     contentPortMap.set(tabId, port);
     if (panelPortMap.has(tabId)) {
       port.postMessage({
-        type: showPanel ? "show_panel" : "hide_panel",
+        type: panelIsOpen ? "panelshow" : "panelhide",
       });
     }
     port.onDisconnect.addListener(() => {
@@ -52,10 +52,10 @@ runtime.onConnect.addListener((port: Runtime.Port) => {
     port.onMessage.addListener((message) => {
       const contentPort = contentPortMap.get(tabId);
       console.log("sent message from panel to content", message, contentPort);
-      if (message.type === "show_panel") {
-        showPanel = true;
-      } else if (message.type === "hide_panel") {
-        showPanel = false;
+      if (message.type === "panelshow") {
+        panelIsOpen = true;
+      } else if (message.type === "panelhide") {
+        panelIsOpen = false;
       }
       contentPort?.postMessage(message);
     });

--- a/packages/swr-devtools-extensions/src/content.ts
+++ b/packages/swr-devtools-extensions/src/content.ts
@@ -1,5 +1,5 @@
 import { DevToolsMessage } from "swr-devtools";
-import { Runtime, devtools, runtime } from "webextension-polyfill";
+import { Runtime, runtime } from "webextension-polyfill";
 
 const injectDevToolsHook = () => {
   const script = document.createElement("script");
@@ -49,16 +49,9 @@ export type ContentMessage =
       tabId: number;
     };
 
-let isDisplayedPanel = false;
-// TODO: how to use the flag?
 let isPanelShown = false;
 
 let port_: Runtime.Port | null = null;
-
-// TODO: リロードされたら必ず false
-// devtools 表示されたら true
-
-console.log({ isPanelShown });
 
 const getPort = () => {
   if (port_ !== null) return port_;
@@ -68,40 +61,23 @@ const getPort = () => {
     console.log("receive event", { message });
     if (message.type === "show_panel") {
       isPanelShown = true;
-      isDisplayedPanel = true;
       window.postMessage({ type: "show_panel" });
     } else if (message.type === "hide_panel") {
       isPanelShown = false;
-      isDisplayedPanel = false;
       window.postMessage({ type: "hide_panel" });
-      // a panel has been displayed, so we sent queued messages
-    } else if (message.type === "displayed_panel") {
-      // isDisplayedPanel = true;
-      window.postMessage({ type: "displayed_panel" });
-    } else if (message.type === "disconnected_panel") {
-      isDisplayedPanel = false;
-      window.postMessage({ type: "disconnected_panel" });
     }
   };
   // cannot get tabId here
   port_.onMessage.addListener(onMessage);
   port_.onDisconnect.addListener(() => {
     console.log("disconnect content panel port");
-    isDisplayedPanel = false;
+    isPanelShown = false;
     port_?.onMessage.removeListener(onMessage);
     port_ = null;
   });
 
   return port_;
 };
-
-// wait for loading applications
-
-setTimeout(() => {
-  window.postMessage({ type: "load", payload: isPanelShown });
-}, 1000);
-
-// proxy messages from applications to a background script
 
 // A new page has been loaded.
 // this event is sent with any pages that don't have SWRDevTools
@@ -114,6 +90,8 @@ window.addEventListener("message", (e: MessageEvent<DevToolsMessage>) => {
   switch (e.data?.type) {
     case "initialized": {
       port.postMessage(e.data);
+      // sync the status of displayed panel
+      window.postMessage({ type: "load", payload: isPanelShown });
       break;
     }
     case "updated_swr_cache":
@@ -121,7 +99,7 @@ window.addEventListener("message", (e: MessageEvent<DevToolsMessage>) => {
     case "request_success":
     case "request_error":
     case "request_discarded": {
-      if (isDisplayedPanel) {
+      if (isPanelShown) {
         port.postMessage(e.data);
       }
       break;

--- a/packages/swr-devtools-extensions/src/content.ts
+++ b/packages/swr-devtools-extensions/src/content.ts
@@ -53,12 +53,16 @@ let panelIsOpen = false;
 
 let port_: Runtime.Port | null = null;
 
+const debug = (...args: any[]) => {
+  // console.log(...args);
+};
+
 const getPort = () => {
   if (port_ !== null) return port_;
-  console.log("reconnect content port");
+  debug("reconnect content port");
   port_ = runtime.connect({ name: "content" });
   const onMessage = (message: any) => {
-    console.log("receive event", { message });
+    debug("receive event", { message });
     if (message.type === "panelshow") {
       panelIsOpen = true;
       window.postMessage({ type: "panelshow" });
@@ -70,7 +74,7 @@ const getPort = () => {
   // cannot get tabId here
   port_.onMessage.addListener(onMessage);
   port_.onDisconnect.addListener(() => {
-    console.log("disconnect content panel port");
+    debug("disconnect content panel port");
     panelIsOpen = false;
     port_?.onMessage.removeListener(onMessage);
     port_ = null;

--- a/packages/swr-devtools-extensions/src/devtools.ts
+++ b/packages/swr-devtools-extensions/src/devtools.ts
@@ -1,5 +1,17 @@
-import { devtools } from "webextension-polyfill";
+import { devtools, runtime } from "webextension-polyfill";
 
-devtools.panels.create("SWR", "", "panel.html").then(() => {
+const port = runtime.connect({
+  name: "panel:" + devtools.inspectedWindow.tabId,
+});
+
+devtools.panels.create("SWR", "", "panel.html").then((panel) => {
+  panel.onHidden.addListener(() => {
+    console.log("hide panel");
+    port.postMessage({ type: "hide_panel" });
+  });
+  panel.onShown.addListener(() => {
+    console.log("show panel");
+    port.postMessage({ type: "show_panel" });
+  });
   console.log("The DevTools panel has been created");
 });

--- a/packages/swr-devtools-extensions/src/devtools.ts
+++ b/packages/swr-devtools-extensions/src/devtools.ts
@@ -1,10 +1,9 @@
 import { devtools, runtime } from "webextension-polyfill";
 
-const port = runtime.connect({
-  name: "panel:" + devtools.inspectedWindow.tabId,
-});
-
 devtools.panels.create("SWR", "", "panel.html").then((panel) => {
+  const port = runtime.connect({
+    name: "panel:" + devtools.inspectedWindow.tabId,
+  });
   panel.onHidden.addListener(() => {
     console.log("hide panel");
     port.postMessage({ type: "hide_panel" });

--- a/packages/swr-devtools-extensions/src/devtools.ts
+++ b/packages/swr-devtools-extensions/src/devtools.ts
@@ -5,11 +5,11 @@ devtools.panels.create("SWR", "", "panel.html").then((panel) => {
     name: "panel:" + devtools.inspectedWindow.tabId,
   });
   panel.onHidden.addListener(() => {
-    console.log("hide panel");
+    // console.log("hide panel");
     port.postMessage({ type: "panelhide" });
   });
   panel.onShown.addListener(() => {
-    console.log("show panel");
+    // console.log("show panel");
     port.postMessage({ type: "panelshow" });
   });
   console.log("The DevTools panel has been created");

--- a/packages/swr-devtools-extensions/src/devtools.ts
+++ b/packages/swr-devtools-extensions/src/devtools.ts
@@ -6,11 +6,11 @@ devtools.panels.create("SWR", "", "panel.html").then((panel) => {
   });
   panel.onHidden.addListener(() => {
     console.log("hide panel");
-    port.postMessage({ type: "hide_panel" });
+    port.postMessage({ type: "panelhide" });
   });
   panel.onShown.addListener(() => {
     console.log("show panel");
-    port.postMessage({ type: "show_panel" });
+    port.postMessage({ type: "panelshow" });
   });
   console.log("The DevTools panel has been created");
 });

--- a/packages/swr-devtools-extensions/src/panel.html
+++ b/packages/swr-devtools-extensions/src/panel.html
@@ -6,7 +6,9 @@
       html {
         height: 100%;
         background-color: white;
-        @media (prefers-color-scheme: dark) {
+      }
+      @media (prefers-color-scheme: dark) {
+        html {
           background-color: rgb(39, 40, 34);
         }
       }
@@ -15,10 +17,30 @@
         height: 100%;
         margin: 0;
       }
+      div#loading {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      div#loading-text {
+        font-size: 1rem;
+        color: rgb(39, 40, 34);
+      }
+      @media (prefers-color-scheme: dark) {
+        div#loading-text {
+          color: white;
+        }
+      }
     </style>
     <script defer src="./app.js"></script>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <div id="loading">
+        <div id="loading-text">Loading SWRDevTools...</div>
+      </div>
+    </div>
   </body>
 </html>

--- a/packages/swr-devtools-extensions/src/panel.html
+++ b/packages/swr-devtools-extensions/src/panel.html
@@ -17,30 +17,10 @@
         height: 100%;
         margin: 0;
       }
-      div#loading {
-        width: 100%;
-        height: 100%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-      }
-      div#loading-text {
-        font-size: 1rem;
-        color: rgb(39, 40, 34);
-      }
-      @media (prefers-color-scheme: dark) {
-        div#loading-text {
-          color: white;
-        }
-      }
     </style>
     <script defer src="./app.js"></script>
   </head>
   <body>
-    <div id="app">
-      <div id="loading">
-        <div id="loading-text">Loading SWRDevTools...</div>
-      </div>
-    </div>
+    <div id="app"></div>
   </body>
 </html>

--- a/packages/swr-devtools-panel/src/components/SWRDevToolPanel.tsx
+++ b/packages/swr-devtools-panel/src/components/SWRDevToolPanel.tsx
@@ -129,9 +129,11 @@ export const SWRDevToolPanel = ({ cache, events }: Props) => {
               />
             )
           ) : (
-            <NoteText>
-              Haven&apos;t received any cache data from SWRDevTools
-            </NoteText>
+            <NotFound>
+              <NotFoundText>
+                Open SWRDevTools on the page using SWR.
+              </NotFoundText>
+            </NotFound>
           )}
         </PanelWrapper>
       </DevToolWindow>
@@ -187,6 +189,14 @@ const PanelWrapper = styled.div`
   height: calc(100% - 36px);
 `;
 
-const NoteText = styled.p`
+const NotFound = styled.div`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.2rem;
+`;
+
+const NotFoundText = styled.p`
   color: var(--swr-devtools-text-color);
 `;

--- a/packages/swr-devtools/src/createSWRDevTools.ts
+++ b/packages/swr-devtools/src/createSWRDevTools.ts
@@ -64,11 +64,11 @@ export type DevToolsMessage =
       };
     };
 
-let isOpenedDevToolsPanel = false;
+let devToolsPanelIsOpen = false;
 
 const inject = (cache: Cache) =>
   injectSWRCache(cache, (key: string, value: any) => {
-    if (isOpenedDevToolsPanel) {
+    if (devToolsPanelIsOpen) {
       window.postMessage(
         {
           type: "updated_swr_cache",
@@ -98,12 +98,12 @@ export const createSWRDevtools = () => {
 
   if (typeof window !== "undefined") {
     window.addEventListener("message", (e) => {
-      if (e.data?.type === "show_panel") {
-        isOpenedDevToolsPanel = true;
-      } else if (e.data?.type === "hide_panel") {
-        isOpenedDevToolsPanel = false;
+      if (e.data?.type === "panelshow") {
+        devToolsPanelIsOpen = true;
+      } else if (e.data?.type === "panelhide") {
+        devToolsPanelIsOpen = false;
       } else if (e.data?.type === "load") {
-        isOpenedDevToolsPanel = e.data?.payload;
+        devToolsPanelIsOpen = e.data?.payload?.panelIsOpen;
       }
     });
   }
@@ -136,7 +136,7 @@ export const createSWRDevtools = () => {
 
     useEffect(() => {
       return () => {
-        if (!isOpenedDevToolsPanel) return;
+        if (!devToolsPanelIsOpen) return;
         // When the key changes or unmounts, ongoing requests should be discarded.
         // This only affects React 17.
         // https://github.com/vercel/swr/blob/bcc39321dd12133a0c42207ef4bdef7e214d9b1e/core/use-swr.ts#L245-L254
@@ -153,10 +153,10 @@ export const createSWRDevtools = () => {
       };
     }, [serializedKey]);
 
-    console.log({ isOpenedDevToolsPanel });
+    console.log({ devToolsPanelIsOpen });
 
     // If DevToolsPanel is not opened, we don't do anything.
-    if (!isOpenedDevToolsPanel) {
+    if (!devToolsPanelIsOpen) {
       return useSWRNext(key, fn, config);
     }
 

--- a/packages/swr-devtools/src/createSWRDevTools.ts
+++ b/packages/swr-devtools/src/createSWRDevTools.ts
@@ -20,6 +20,10 @@ export class EventEmitter {
   }
 }
 
+const debug = (...args: any[]) => {
+  // console.log(...args);
+};
+
 const injected = new WeakSet();
 
 export type DevToolsMessage =
@@ -153,7 +157,7 @@ export const createSWRDevtools = () => {
       };
     }, [serializedKey]);
 
-    console.log({ devToolsPanelIsOpen });
+    debug({ devToolsPanelIsOpen });
 
     // If DevToolsPanel is not opened, we don't do anything.
     if (!devToolsPanelIsOpen) {


### PR DESCRIPTION
This is a part of #100 
This PR makes SWRDevTools send events only when the SWRDevTools panel is open, which means your application doesn't get slower as long as opening SWRDevTools panel.