### PR TITLE
fix: remove duplicate React instance

### DIFF
--- a/packages/swr-devtools-extensions/src/web-accessible.ts
+++ b/packages/swr-devtools-extensions/src/web-accessible.ts
@@ -1,4 +1,4 @@
-import { createSWRDevtools } from "swr-devtools";
+import { createSWRDevtools } from "swr-devtools/lib/createSWRDevTools";
 
 const [middleware] = createSWRDevtools();
 

--- a/packages/swr-devtools/package.json
+++ b/packages/swr-devtools/package.json
@@ -15,6 +15,11 @@
       "import": "./lib/swr-cache.js",
       "require": "./cjs/swr-cache.js",
       "types": "./lib/swr-cache.d.ts"
+    },
+    "./lib/createSWRDevTools": {
+      "import": "./lib/createSWRDevTools.js",
+      "require": "./cjs/createSWRDevTools.js",
+      "types": "./lib/createSWRDevTools.d.ts"
     }
   },
   "types": "lib/index.d.ts",

--- a/packages/swr-devtools/src/createSWRDevTools.ts
+++ b/packages/swr-devtools/src/createSWRDevTools.ts
@@ -1,8 +1,9 @@
 // We cannot import React nad use hooks that SWR provides because this runs on the application side,
 // we have to use the same React instance with the application
-import { Middleware, Cache, unstable_serialize } from "swr";
+import type { Middleware, Cache } from "swr";
 
 import { injectSWRCache, serializePayload } from "./swr-cache";
+import { serialize as unstable_serialize } from "./swr/serialize";
 
 type EventListener = (...args: any[]) => void;
 

--- a/packages/swr-devtools/src/swr-cache.ts
+++ b/packages/swr-devtools/src/swr-cache.ts
@@ -1,4 +1,4 @@
-import { Cache } from "swr";
+import type { Cache } from "swr";
 import superjson from "superjson";
 
 export type DevToolsCacheData = {

--- a/packages/swr-devtools/src/swr/hash.ts
+++ b/packages/swr-devtools/src/swr/hash.ts
@@ -1,0 +1,72 @@
+// Taken from https://github.com/vercel/swr/blob/9ea4a45c1620b31fb3a5a09771e0809638f47974/_internal/utils/hash.ts
+const OBJECT = Object;
+const isUndefined = (v: any) => typeof v === "undefined";
+
+// use WeakMap to store the object->key mapping
+// so the objects can be garbage collected.
+// WeakMap uses a hashtable under the hood, so the lookup
+// complexity is almost O(1).
+const table = new WeakMap<object, number | string>();
+
+// counter of the key
+let counter = 0;
+
+// A stable hash implementation that supports:
+// - Fast and ensures unique hash properties
+// - Handles unserializable values
+// - Handles object key ordering
+// - Generates short results
+//
+// This is not a serialization function, and the result is not guaranteed to be
+// parsable.
+export const stableHash = (arg: any): string => {
+  const type = typeof arg;
+  const constructor = arg && arg.constructor;
+  const isDate = constructor == Date;
+
+  let result: any;
+  let index: any;
+
+  if (OBJECT(arg) === arg && !isDate && constructor != RegExp) {
+    // Object/function, not null/date/regexp. Use WeakMap to store the id first.
+    // If it's already hashed, directly return the result.
+    result = table.get(arg);
+    if (result) return result;
+
+    // Store the hash first for circular reference detection before entering the
+    // recursive `stableHash` calls.
+    // For other objects like set and map, we use this id directly as the hash.
+    result = ++counter + "~";
+    table.set(arg, result);
+
+    if (constructor == Array) {
+      // Array.
+      result = "@";
+      for (index = 0; index < arg.length; index++) {
+        result += stableHash(arg[index]) + ",";
+      }
+      table.set(arg, result);
+    }
+    if (constructor == OBJECT) {
+      // Object, sort keys.
+      result = "#";
+      const keys = OBJECT.keys(arg).sort();
+      while (!isUndefined((index = keys.pop() as string))) {
+        if (!isUndefined(arg[index])) {
+          result += index + ":" + stableHash(arg[index]) + ",";
+        }
+      }
+      table.set(arg, result);
+    }
+  } else {
+    result = isDate
+      ? arg.toJSON()
+      : type == "symbol"
+      ? arg.toString()
+      : type == "string"
+      ? JSON.stringify(arg)
+      : "" + arg;
+  }
+
+  return result;
+};

--- a/packages/swr-devtools/src/swr/serialize.ts
+++ b/packages/swr-devtools/src/swr/serialize.ts
@@ -1,0 +1,25 @@
+// Taken from https://github.com/vercel/swr/blob/9ea4a45c1620b31fb3a5a09771e0809638f47974/_internal/utils/serialize.ts
+import { stableHash } from "./hash";
+
+const isFunction = (v: any) => typeof v === "function";
+
+export const serialize = (key: any): string => {
+  if (isFunction(key)) {
+    try {
+      key = key();
+    } catch (err) {
+      // dependencies not ready
+      key = "";
+    }
+  }
+
+  // If key is not falsy, or not an empty array, hash it.
+  key =
+    typeof key === "string"
+      ? key
+      : (Array.isArray(key) ? key.length : key)
+      ? stableHash(key)
+      : "";
+
+  return key;
+};


### PR DESCRIPTION
Sometimes, an error occurred due to duplicating React instances, which is caused by using `unstable_serialize` from `swr`.
This is not the ideal solution, but I've temporarily copied the serialization logic from `swr` and removed `react` as the dependency of `web-accessible.js`.