### PR TITLE
fix: ignore DOMException by accessing localStorage

### DIFF
--- a/packages/swr-devtools-panel/src/components/ThemeProvider.tsx
+++ b/packages/swr-devtools-panel/src/components/ThemeProvider.tsx
@@ -7,8 +7,7 @@ const initialTheme = (): Theme => {
   if (typeof window === "undefined") return "system";
   let theme: Theme = "system";
   try {
-    // @ts-expect-error
-    theme = localStorage.getItem(THEME_KEY);
+    theme = localStorage.getItem(THEME_KEY) as Theme;
   } catch {
     // noop
   }

--- a/packages/swr-devtools-panel/src/components/ThemeProvider.tsx
+++ b/packages/swr-devtools-panel/src/components/ThemeProvider.tsx
@@ -5,8 +5,14 @@ const THEME_KEY = "$swr-devtools:theme";
 
 const initialTheme = (): Theme => {
   if (typeof window === "undefined") return "system";
-  // @ts-expect-error
-  return localStorage.getItem(THEME_KEY) || "system";
+  let theme: Theme = "system";
+  try {
+    // @ts-expect-error
+    theme = localStorage.getItem(THEME_KEY);
+  } catch {
+    // noop
+  }
+  return theme;
 };
 
 const getThemeByPreference = () =>
@@ -42,7 +48,11 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     setTheme(initialTheme());
   }, []);
   useEffect(() => {
-    localStorage.setItem(THEME_KEY, theme);
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch {
+      // noop
+    }
   }, [theme]);
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>


### PR DESCRIPTION
fixes #122

SWRDevTools uses `localStorage` on the devtools page to store the theme setting. But it sometimes causes a DOMException. So I'll ignore the error. If the error occurs, we use `system` as the default value.