### PR TITLE
fix: crash on multiple SWR instances

### DIFF
--- a/packages/swr-devtools/src/createSWRDevTools.ts
+++ b/packages/swr-devtools/src/createSWRDevTools.ts
@@ -113,16 +113,16 @@ export const createSWRDevtools = () => {
     });
   }
 
-  const swrdevtools: Middleware = (useSWRNext) => (key, fn, config) => {
-    // use the same React instance with the application
-    const { useLayoutEffect, useEffect, useRef } =
-      typeof window !== "undefined" &&
-      // @ts-expect-error
-      typeof window.__SWR_DEVTOOLS_REACT__ !== "undefined"
-        ? // @ts-expect-error
-          window.__SWR_DEVTOOLS_REACT__
-        : dummyHooks;
+  // use the same React instance with the application
+  const { useLayoutEffect, useEffect, useRef } =
+    typeof window !== "undefined" &&
+    // @ts-expect-error
+    typeof window.__SWR_DEVTOOLS_REACT__ !== "undefined"
+      ? // @ts-expect-error
+        window.__SWR_DEVTOOLS_REACT__
+      : dummyHooks;
 
+  const swrdevtools: Middleware = (useSWRNext) => (key, fn, config) => {
     useLayoutEffect(() => {
       window.postMessage({ type: "initialized" }, "*");
     }, []);


### PR DESCRIPTION
refs #125 
I've tested on https://github.com/clerkinc/clerk-next-app, and the application doesn't crash with a component using SWR.
SWRDevTools shouldn't affect main applications, so this is not an ideal fix, but this mitigates some issues.